### PR TITLE
Update guide.md

### DIFF
--- a/en/docs/docs/guides/database-static-rule-processing/guide.md
+++ b/en/docs/docs/guides/database-static-rule-processing/guide.md
@@ -146,7 +146,7 @@ select GetPromoCardTypeStream.messageId, GetPromoCardTypeStream.promoCardId, Get
 insert into GetPromoCardTypeDetailsStream;
 
 @info(name='get-promocard-rules')
-from GetPromoCardTypeDetailsStream#window.length(1) right outer join PromoRule on GetPromoCardTypeDetailsStream.promoCardTypeId==PromoRule.promoCardTypeId
+from GetPromoCardTypeDetailsStream#window.length(1) left outer join PromoRule on GetPromoCardTypeDetailsStream.promoCardTypeId==PromoRule.promoCardTypeId
 select GetPromoCardTypeDetailsStream.messageId, GetPromoCardTypeDetailsStream.promoCardId, GetPromoCardTypeDetailsStream.promoCardTypeId, GetPromoCardTypeDetailsStream.amount, GetPromoCardTypeDetailsStream.promoCardTypeDiscount, PromoRule.promoRuleId, PromoRule.promoRule, GetPromoCardTypeDetailsStream.promoCardIssueDate
 insert into RuleStream;
 


### PR DESCRIPTION
When customer use promoCard PC002 which type is PCT02, because PCT02 has no Promo Rule in Promo Card Rule Table, right outer join with no query data, and the client will wait and wait, without the response. So right outer join should be changed to left outer join.